### PR TITLE
build: update release rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,62 @@
       "main"
     ],
     "plugins": [
-      "@semantic-release/commit-analyzer",
+      [
+        "@semantic-release/commit-analyzer",
+        {
+          "preset": "angular",
+          "releaseRules": [
+            {
+              "breaking": true,
+              "release": "major"
+            },
+            {
+              "revert": true,
+              "release": "patch"
+            },
+            {
+              "type": "feat",
+              "release": "minor"
+            },
+            {
+              "type": "build",
+              "release": "minor"
+            },
+            {
+              "type": "refactor",
+              "release": "minor"
+            },
+            {
+              "type": "fix",
+              "release": "patch"
+            },
+            {
+              "type": "perf",
+              "release": "patch"
+            },
+            {
+              "type": "docs",
+              "release": "patch"
+            },
+            {
+              "type": "style",
+              "release": "patch"
+            },
+            {
+              "type": "test",
+              "release": "patch"
+            },
+            {
+              "type": "ci",
+              "release": "patch"
+            },
+            {
+              "type": "chore",
+              "release": "patch"
+            }
+          ]
+        }
+      ],
       "@semantic-release/release-notes-generator",
       "@semantic-release/github"
     ]


### PR DESCRIPTION
## Goal
<!-- Please describe the goal of this PR. -->
Update release rules to make each commit generate a release note.

https://github.com/dazedbear/rubber-duck-game/runs/6613025475?check_suite_focus=true

<img width="909" alt="截圖 2022-05-27 上午1 03 04" src="https://user-images.githubusercontent.com/8896191/170538273-3ce04e22-f941-4fd7-8a47-7f4089fa3120.png">


## Reference
<!-- Any reference for this PR -->
- [release rules mechanism of `@semantic-release/commit-analyzer`](https://github.com/semantic-release/commit-analyzer#releaserules)
- [default release rules](https://github.com/semantic-release/commit-analyzer/blob/master/lib/default-release-rules.js)